### PR TITLE
Version that can use the TEMPO2 barycentring routines

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -49,6 +49,10 @@ OPTFLAGS=-O3 -ffast-math -ftree-vectorizer-verbose=6 -ftree-vectorize -mavx -DOP
 # icc optimizations (see README) #
 #OPTFLAGS=-O3 -xHOST -DOPTIMIZE_AVX
 
+#TEMPO= # if you do not have TEMPO2 install
+TEMPO=-DMODEL_TEMPO
+TEMPOLIBS=-lsofa -ltempo2
+TEMPOFLAGS=-L/usr/local/lib -I/usr/local/include
 
 ### model specific flags, headers, sources ###
 MODELFLAGS=
@@ -107,14 +111,14 @@ $(BINDIR)/greedyOMP: $(SRCDIR)/greedy.cpp $(SOURCES) $(HEADERS) $(MODELSOURCES) 
 	$(SOURCES) $(MODELSOURCES) $(LDLIBS) $(MODELLIBS) $(NUMPYLIBS)
 
 $(BINDIR)/greedyBarycenterOMP: $(SRCDIR)/greedy_barycenter.cpp $(SOURCES) $(HEADERS) $(MODELSOURCES) $(MODELHEADERS)
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(MODELFLAGS) $(OPENMP) $(LAL) $(NUMPY) $(GIT_FLAGS) \
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(MODELFLAGS) $(TEMPOFLAGS) $(OPENMP) $(LAL) $(NUMPY) $(TEMPO) $(GIT_FLAGS) \
 	$(NUMPYHEADERS) -DCOMPILE_WITHOUT_MPI -o $(BINDIR)/greedyBarycenterOMP $(SRCDIR)/greedy_barycenter.cpp \
-	$(SOURCES) $(MODELSOURCES) $(LDLIBS) $(MODELLIBS) $(NUMPYLIBS)
+	$(SOURCES) $(MODELSOURCES) $(LDLIBS) $(MODELLIBS) $(NUMPYLIBS) $(TEMPOLIBS)
 
 $(BINDIR)/greedyBarycenter: $(SRCDIR)/greedy_barycenter.cpp $(SOURCES) $(HEADERS) $(MODELSOURCES) $(MODELHEADERS)
-	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(MODELFLAGS) -fopenmp $(LAL) $(NUMPY) $(GIT_FLAGS) \
+	$(CXX) $(CXXFLAGS) $(OPTFLAGS) $(MODELFLAGS) $(TEMPOFLAGS) -fopenmp $(LAL) $(NUMPY) $(TEMPO) $(GIT_FLAGS) \
 	$(NUMPYHEADERS) -DCOMPILE_WITHOUT_MPI -o $(BINDIR)/greedyBarycenter $(SRCDIR)/greedy_barycenter.cpp \
-	$(SOURCES) $(MODELSOURCES) $(LDLIBS) $(MODELLIBS) $(NUMPYLIBS)
+	$(SOURCES) $(MODELSOURCES) $(LDLIBS) $(MODELLIBS) $(NUMPYLIBS) $(TEMPOLIBS)
 
 $(BINDIR)/greedy_mpi: $(SRCDIR)/greedy.cpp $(SOURCES) $(HEADERS) $(MODELSOURCES) $(MODELHEADERS)
 	$(CXX_MPI) $(CXXFLAGS) $(OPTFLAGS) $(MODELFLAGS) -fopenmp $(LAL) $(NUMPY) $(GIT_FLAGS) \

--- a/models/lal/Barycenter.h
+++ b/models/lal/Barycenter.h
@@ -20,6 +20,7 @@ extern "C"{
 #include <lal/LALInitBarycenter.h>
 #include <lal/SFTutils.h>
 #include <lal/BinaryPulsarTiming.h>
+#include <lal/Date.h>
 
 #include <omp.h>
 
@@ -175,7 +176,7 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       else{
         GSL_SET_COMPLEX(&emitdt, emit.deltaT, 0.);
       }
-
+      fprintf(stderr, "time = %.16lf\n", emit.roemer);
       // fill in the output training buffer
       gsl_vector_complex_set(wv, i, emitdt);
     }
@@ -197,6 +198,9 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       gsl_complex emitdt;
       REAL8 shapirodelay = 0.;
       thistime = (thistime/86400.) + 44244.; // convert to MJD
+
+      // subtract leap seconds from MJD time to get GPS reference (using XLALGPSLeapSeconds( (UINT4)t ))
+      thistime -= XLALGPSLeapSeconds( (UINT4)thistime ); // CHECK THIS
 
       psr[0].obsn[0].sat = (long double)thistime;
 

--- a/models/lal/Barycenter.h
+++ b/models/lal/Barycenter.h
@@ -208,8 +208,8 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       calculate_bclt(psr, 1);
 
       // get barycenter time delat
-      batdt = getCorrectionTT(psr[0].obsn+i)/86400. + (psr[0].obsn[0].correctionTT_TB
-               + psr[0].obsn[0].roemer)/SECDAY;
+      batdt = getCorrectionTT(psr[0].obsn+i) + psr[0].obsn[0].correctionTT_TB
+               + psr[0].obsn[0].roemer;
       
       if ( !noshapiro ){ // remove Shapiro delay
         shapirodelay = psr[0].obsn[0].shapiroDelaySun; // only include Sun
@@ -218,7 +218,8 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       GSL_SET_COMPLEX(&emitdt, batdt - shapirodelay, 0.); // subtract shapiro as in TEMPO
 
       // fill in the output training buffer
-      //if ( i == 0 ){ fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt)); }
+      //fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt));
+      //fprintf(stderr, "time = %.16Lf\n", psr[0].obsn[0].roemer);
       gsl_vector_complex_set(wv, i, emitdt);
     }
   }

--- a/models/lal/Barycenter.h
+++ b/models/lal/Barycenter.h
@@ -124,25 +124,24 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
     psr = (pulsar *)malloc(sizeof(pulsar)*1);
     MAX_OBSN = n; // define MAX_OBSN (in tempo2.h) as the number of observations
     initialiseOne(psr, 1, 1); // initialise pulsar
-  
-    strcpy(psr[0].JPL_EPHEMERIS, getenv(TEMPO2_ENVIRON));
-    char epfile[256];
-    snprintf(epfile, sizeof(char)*256, "/ephemeris/%s.1950.2050", vals[1].c_str());
-    strcpy(psr[0].ephemeris, vals[1].c_str());
-    strcat(psr[0].JPL_EPHEMERIS, epfile);
+
+    char epfile[MAX_FILELEN];
+    snprintf(epfile, sizeof(char)*MAX_FILELEN, "%s/ephemeris/%s.1950.2050", getenv(TEMPO2_ENVIRON), vals[1].c_str());
+    strncpy(psr[0].ephemeris, vals[1].c_str(), sizeof(char)*MAX_FILELEN);
+    strncpy(psr[0].JPL_EPHEMERIS, epfile, sizeof(char)*MAX_FILELEN);
 
     if ( !strcmp("TCB", vals[2].c_str()) ){ psr[0].units = SI_UNITS; }
     if ( !strcmp("TDB", vals[2].c_str()) ){ psr[0].units = TDB_UNITS; }
 
     // set the site (assume that LIGO sites have been added to the TEMPO2 observatories file)
     if ( strstr(vals[0].c_str(), "H1") != NULL ){
-      strcpy(psr[0].obsn[0].telID, "HANFORD");
+      strncpy(psr[0].obsn[0].telID, "HANFORD", sizeof(psr[0].obsn[0].telID));
     }
     else if ( strstr(vals[0].c_str(), "L1") != NULL ){
-      strcpy(psr[0].obsn[0].telID, "LIVINGSTON");
+      strncpy(psr[0].obsn[0].telID, "LIVINGSTON", sizeof(psr[0].obsn[0].telID));
     }
     else if ( strstr(vals[0].c_str(), "V1") != NULL ){ 
-      strcpy(psr[0].obsn[0].telID, "VIRGO");
+      strncpy(psr[0].obsn[0].telID, "VIRGO", sizeof(psr[0].obsn[0].telID));
     }
     else{
       fprintf(stderr, "Error... detector not found.\n");
@@ -179,7 +178,7 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
         GSL_SET_COMPLEX(&emitdt, emit.deltaT, 0.);
       }
 
-      //if ( i == 523 ){ fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt)); }
+      //if ( i == 523 ){ fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt)); } // for testing
       // fill in the output training buffer
       gsl_vector_complex_set(wv, i, emitdt);
     }
@@ -216,7 +215,7 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       psr[0].obsn[i].sat = (long double)mjd;
 
       if ( i > 0 ){
-        strcpy(psr[0].obsn[i].telID, psr[0].obsn[0].telID);
+        strncpy(psr[0].obsn[i].telID, psr[0].obsn[0].telID, sizeof(psr[0].obsn[0].telID));
       }
     }
 
@@ -237,10 +236,11 @@ void Barycenter_Waveform(gsl_vector_complex *wv,
       GSL_SET_COMPLEX(&emitdt, batdt - shapirodelay, 0.); // subtract shapiro as in TEMPO
 
       // fill in the output training buffer
-      //if ( i == 523 ){ fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt)); }
+      //if ( i == 523 ){ fprintf(stderr, "time = %.16lf\n", GSL_REAL(emitdt)); } // for testing
       gsl_vector_complex_set(wv, i, emitdt);
     }
     destroyOne(psr); // free memory
+    free(psr);
   }
 #endif
 }

--- a/models/lal/lal_helpers.cpp
+++ b/models/lal/lal_helpers.cpp
@@ -205,16 +205,31 @@ std::string model_tag2mode_part(const std::string model_tag,
 std::vector<std::string> get_barycenter_tags(const std::string model_tag){
   std::vector<std::string> x = split_string(model_tag, '_'); // split tag on underscores
 
-  if ( x.size() != 4 && x.size() != 5 ){
-    fprintf(stderr, "Model tag should have format \"Barycenter_DET_EPHEM_UNITS\" or \"Barycenter_DET_EPHEM_UNITS_NOSHAPIRO\"\n");
+  if ( x.size() != 4 && x.size() != 5 && x.size() != 6 ){
+    fprintf(stderr, "Model tag should have format \"Barycenter_DET_EPHEM_UNITS\", \"Barycenter_DET_EPHEM_UNITS_TEMPO\", \"Barycenter_DET_EPHEM_UNITS_NOSHAPIRO\" or \"Barycenter_DET_EPHEM_UNITS_TEMPO_NOSHAPIRO\"\n");
     exit(1);
   }
   // get the last three parts of the vector (i.e. DET, EPHEM, UNITS)
   std::vector<std::string> y(x.begin()+1, x.begin()+4);
 
   // add whether to include Shapiro delay in model or not
-  if ( x.size() == 4 ){ y.push_back("SHAPIRO"); }
-  else { y.push_back(x[4]); } 
+  if ( x.size() == 4 ){
+    y.push_back("SHAPIRO");
+    y.push_back("NOTEMPO");
+  }
+  else if ( x.size() == 5 ) {
+    if ( !strcmp(x[4].c_str(), "TEMPO"){
+      y.push_back("SHAPIRO");
+      y.push_back("TEMPO");
+    }
+    else{
+      y.push_back(x[4]);
+      y.push_back("NOTEMPO");
+    }
+  else{
+    y.push_back(x[5]); // NOSHAPIRO
+    y.push_back(x[4]); // TEMPO
+  }
 
   // check ephem is DE200, DE405, DE414 or DE421
   if ( strcmp(y[1].c_str(), "DE200") && strcmp(y[1].c_str(), "DE405") &&

--- a/models/lal/lal_helpers.cpp
+++ b/models/lal/lal_helpers.cpp
@@ -251,7 +251,7 @@ std::vector<std::string> get_barycenter_tags(const std::string model_tag){
     exit(1);
   }
 
-  fprintf(stdout, "Detector: \"%s\", ephemeris: \"%s\", time units: \"%s\"\n", y[0].c_str(), y[1].c_str(), y[2].c_str());
+  fprintf(stdout, "Detector: \"%s\", ephemeris: \"%s\", time units: \"%s\", TEMPO: \"%s\"\n", y[0].c_str(), y[1].c_str(), y[2].c_str(), y[4].c_str());
 
   return y;
 }

--- a/models/lal/lal_helpers.cpp
+++ b/models/lal/lal_helpers.cpp
@@ -218,7 +218,7 @@ std::vector<std::string> get_barycenter_tags(const std::string model_tag){
     y.push_back("NOTEMPO");
   }
   else if ( x.size() == 5 ) {
-    if ( !strcmp(x[4].c_str(), "TEMPO"){
+    if ( !strcmp(x[4].c_str(), "TEMPO") ){
       y.push_back("SHAPIRO");
       y.push_back("TEMPO");
     }
@@ -226,6 +226,7 @@ std::vector<std::string> get_barycenter_tags(const std::string model_tag){
       y.push_back(x[4]);
       y.push_back("NOTEMPO");
     }
+  }
   else{
     y.push_back(x[5]); // NOSHAPIRO
     y.push_back(x[4]); // TEMPO


### PR DESCRIPTION
I have altered [Barycenter.h](https://github.com/mattpitkin/greedycpp/blob/redordbar/models/lal/Barycenter.h), so that rather than using the LALSuite barycentering routines it can use those in [TEMPO2](https://bitbucket.org/psrsoft/tempo2/) (in particular the version of TEMPO2 after commit [f91820a](https://bitbucket.org/psrsoft/tempo2/commits/f91820a), where the LIGO, Virgo, GEO600 and KAGRA GW detector location were added). This obviously requires TEMPO2 to be installed, as per the [instructions](https://bitbucket.org/psrsoft/tempo2/), using an installation location of `/usr/local/`.

I have tested that the LAL routines and TEMPO2 routines give similar answers, and (for the few points I've tested) they agree to within a few 10<sup>-7</sup> seconds or better, which I think is about the expected agreement.